### PR TITLE
fix(CP-2515): No @db.Text for @id and @unique fields

### DIFF
--- a/src/fileTransformers/mysqlSchemaTypeTransformer.ts
+++ b/src/fileTransformers/mysqlSchemaTypeTransformer.ts
@@ -1,13 +1,5 @@
 import { FileTransformer } from '~/src/fileTransformer/fileTransformer'
 
-/**
- * @description
- * Schema type transform examples:
- *  String? -> String? @db.Text
- *  String -> String @db.Text
- *  String @id -> String
- *  String @unique -> String
- */
 export const mysqlSchemaTypeTransformer: FileTransformer = (params) => {
   const { file, parameters } = params
 
@@ -15,6 +7,14 @@ export const mysqlSchemaTypeTransformer: FileTransformer = (params) => {
     return file.content
   }
 
+  /**
+   * @description
+   * Regex transformation examples:
+   * - String? -> String? @db.Text
+   * - String -> String @db.Text
+   * - String @id -> String
+   * - String @unique -> String
+   */
   const regex = / (String\??)(?!.*(?:@unique|@id))/gm
   return file.content.replace(regex, ` $1 @db.Text`)
 }

--- a/src/fileTransformers/mysqlSchemaTypeTransformer.ts
+++ b/src/fileTransformers/mysqlSchemaTypeTransformer.ts
@@ -1,5 +1,13 @@
 import { FileTransformer } from '~/src/fileTransformer/fileTransformer'
 
+/**
+ * @description
+ * Schema type transform examples:
+ *  String? -> String? @db.Text
+ *  String -> String @db.Text
+ *  String @id -> String
+ *  String @unique -> String
+ */
 export const mysqlSchemaTypeTransformer: FileTransformer = (params) => {
   const { file, parameters } = params
 
@@ -7,11 +15,6 @@ export const mysqlSchemaTypeTransformer: FileTransformer = (params) => {
     return file.content
   }
 
-  // regex used to replace:
-  // String? -> String? @db.Text
-  // String -> String @db.Text
-  // String @id -> String
-  // String @unique -> String
   const regex = / (String\??)(?!.*(?:@unique|@id))/gm
   return file.content.replace(regex, ` $1 @db.Text`)
 }

--- a/src/fileTransformers/mysqlSchemaTypeTransformer.ts
+++ b/src/fileTransformers/mysqlSchemaTypeTransformer.ts
@@ -7,5 +7,11 @@ export const mysqlSchemaTypeTransformer: FileTransformer = (params) => {
     return file.content
   }
 
-  return file.content.replace(/ (String\??)/g, ` $1 @db.Text`)
+  // regex used to replace:
+  // String? -> String? @db.Text
+  // String -> String @db.Text
+  // String @id -> String
+  // String @unique -> String
+  const regex = / (String\??)(?!.*(?:@unique|@id))/gm
+  return file.content.replace(regex, ` $1 @db.Text`)
 }

--- a/tests/__snapshots__/dataproxy.spec.ts.snap
+++ b/tests/__snapshots__/dataproxy.spec.ts.snap
@@ -27,7 +27,7 @@ model Profile {
 }
 
 model User {
-  email    String @db.Text    @unique
+  email    String    @unique
   name     String? @db.Text
   user_id  Int       @id @default(autoincrement())
   posts    Post[]
@@ -68,17 +68,17 @@ provider = \\"mysql\\"
 }
 
 model User {
-  id           String @db.Text        @id @default(uuid())
+  id           String        @id @default(uuid())
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
   name         String @db.Text
-  email        String @db.Text        @unique
+  email        String        @unique
   interactions Interaction[]
   playlists    Playlist[]
 }
 
 model Interaction {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   songId    String? @db.Text
@@ -90,7 +90,7 @@ model Interaction {
 }
 
 model Song {
-  id           String @db.Text        @id @default(uuid())
+  id           String        @id @default(uuid())
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
   name         String @db.Text
@@ -107,7 +107,7 @@ model Song {
 }
 
 model Artist {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   name      String @db.Text
@@ -116,7 +116,7 @@ model Artist {
 }
 
 model Album {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   name      String @db.Text
@@ -126,7 +126,7 @@ model Album {
 }
 
 model Playlist {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   userId    String? @db.Text
@@ -153,17 +153,17 @@ provider = \\"mysql\\"
 }
 
 model User {
-  id           String @db.Text        @id @default(uuid())
+  id           String        @id @default(uuid())
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
-  email        String @db.Text        @unique
+  email        String        @unique
   name         String @db.Text
   reservations Reservation[]
   reviews      Review[]
 }
 
 model Reservation {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   userId    String? @db.Text
@@ -177,7 +177,7 @@ model Reservation {
 }
 
 model Room {
-  id                 String @db.Text        @id @default(uuid())
+  id                 String        @id @default(uuid())
   createdAt          DateTime      @default(now())
   updatedAt          DateTime      @updatedAt
   totalOccupancy     Int           @default(5)
@@ -196,7 +196,7 @@ model Room {
 }
 
 model Review {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   rating    Int
@@ -206,7 +206,7 @@ model Review {
 }
 
 model Media {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   roomId    String? @db.Text
@@ -232,7 +232,7 @@ provider = \\"mysql\\"
 }
 
 model User {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   name      String? @db.Text
@@ -242,7 +242,7 @@ model User {
 }
 
 model Account {
-  id                   String @db.Text   @id @default(uuid())
+  id                   String   @id @default(uuid())
   createdAt            DateTime @default(now())
   updatedAt            DateTime @updatedAt
   stripeCustomerId     String @db.Text
@@ -254,7 +254,7 @@ model Account {
 }
 
 model Invite {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   dateSent  DateTime @default(now())
   email     String @db.Text
   accountId String? @db.Text
@@ -280,7 +280,7 @@ provider = \\"mysql\\"
 }
 
 model Link {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   url       String @db.Text
@@ -290,7 +290,7 @@ model Link {
 }
 
 model User {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   name      String? @db.Text

--- a/tests/__snapshots__/templates-instances.spec.ts.snap
+++ b/tests/__snapshots__/templates-instances.spec.ts.snap
@@ -2504,7 +2504,7 @@ model Profile {
 }
 
 model User {
-  email    String @db.Text    @unique
+  email    String    @unique
   name     String? @db.Text
   user_id  Int       @id @default(autoincrement())
   posts    Post[]
@@ -9335,17 +9335,17 @@ provider = \\"mysql\\"
 }
 
 model User {
-  id           String @db.Text        @id @default(uuid())
+  id           String        @id @default(uuid())
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
   name         String @db.Text
-  email        String @db.Text        @unique
+  email        String        @unique
   interactions Interaction[]
   playlists    Playlist[]
 }
 
 model Interaction {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   songId    String? @db.Text
@@ -9357,7 +9357,7 @@ model Interaction {
 }
 
 model Song {
-  id           String @db.Text        @id @default(uuid())
+  id           String        @id @default(uuid())
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
   name         String @db.Text
@@ -9374,7 +9374,7 @@ model Song {
 }
 
 model Artist {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   name      String @db.Text
@@ -9383,7 +9383,7 @@ model Artist {
 }
 
 model Album {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   name      String @db.Text
@@ -9393,7 +9393,7 @@ model Album {
 }
 
 model Playlist {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   userId    String? @db.Text
@@ -16159,17 +16159,17 @@ provider = \\"mysql\\"
 }
 
 model User {
-  id           String @db.Text        @id @default(uuid())
+  id           String        @id @default(uuid())
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
-  email        String @db.Text        @unique
+  email        String        @unique
   name         String @db.Text
   reservations Reservation[]
   reviews      Review[]
 }
 
 model Reservation {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   userId    String? @db.Text
@@ -16183,7 +16183,7 @@ model Reservation {
 }
 
 model Room {
-  id                 String @db.Text        @id @default(uuid())
+  id                 String        @id @default(uuid())
   createdAt          DateTime      @default(now())
   updatedAt          DateTime      @updatedAt
   totalOccupancy     Int           @default(5)
@@ -16202,7 +16202,7 @@ model Room {
 }
 
 model Review {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   rating    Int
@@ -16212,7 +16212,7 @@ model Review {
 }
 
 model Media {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   roomId    String? @db.Text
@@ -21840,7 +21840,7 @@ provider = \\"mysql\\"
 }
 
 model User {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   name      String? @db.Text
@@ -21850,7 +21850,7 @@ model User {
 }
 
 model Account {
-  id                   String @db.Text   @id @default(uuid())
+  id                   String   @id @default(uuid())
   createdAt            DateTime @default(now())
   updatedAt            DateTime @updatedAt
   stripeCustomerId     String @db.Text
@@ -21862,7 +21862,7 @@ model Account {
 }
 
 model Invite {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   dateSent  DateTime @default(now())
   email     String @db.Text
   accountId String? @db.Text
@@ -26025,7 +26025,7 @@ provider = \\"mysql\\"
 }
 
 model Link {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   url       String @db.Text
@@ -26035,7 +26035,7 @@ model Link {
 }
 
 model User {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   name      String? @db.Text
@@ -28352,7 +28352,7 @@ model Profile {
 }
 
 model User {
-  email    String @db.Text    @unique
+  email    String    @unique
   name     String? @db.Text
   user_id  Int       @id @default(autoincrement())
   posts    Post[]
@@ -28395,17 +28395,17 @@ provider = \\"mysql\\"
 }
 
 model User {
-  id           String @db.Text        @id @default(uuid())
+  id           String        @id @default(uuid())
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
   name         String @db.Text
-  email        String @db.Text        @unique
+  email        String        @unique
   interactions Interaction[]
   playlists    Playlist[]
 }
 
 model Interaction {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   songId    String? @db.Text
@@ -28417,7 +28417,7 @@ model Interaction {
 }
 
 model Song {
-  id           String @db.Text        @id @default(uuid())
+  id           String        @id @default(uuid())
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
   name         String @db.Text
@@ -28434,7 +28434,7 @@ model Song {
 }
 
 model Artist {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   name      String @db.Text
@@ -28443,7 +28443,7 @@ model Artist {
 }
 
 model Album {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   name      String @db.Text
@@ -28453,7 +28453,7 @@ model Album {
 }
 
 model Playlist {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   userId    String? @db.Text
@@ -28481,17 +28481,17 @@ provider = \\"mysql\\"
 }
 
 model User {
-  id           String @db.Text        @id @default(uuid())
+  id           String        @id @default(uuid())
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
-  email        String @db.Text        @unique
+  email        String        @unique
   name         String @db.Text
   reservations Reservation[]
   reviews      Review[]
 }
 
 model Reservation {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   userId    String? @db.Text
@@ -28505,7 +28505,7 @@ model Reservation {
 }
 
 model Room {
-  id                 String @db.Text        @id @default(uuid())
+  id                 String        @id @default(uuid())
   createdAt          DateTime      @default(now())
   updatedAt          DateTime      @updatedAt
   totalOccupancy     Int           @default(5)
@@ -28524,7 +28524,7 @@ model Room {
 }
 
 model Review {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   rating    Int
@@ -28534,7 +28534,7 @@ model Review {
 }
 
 model Media {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   roomId    String? @db.Text
@@ -28561,7 +28561,7 @@ provider = \\"mysql\\"
 }
 
 model User {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   name      String? @db.Text
@@ -28571,7 +28571,7 @@ model User {
 }
 
 model Account {
-  id                   String @db.Text   @id @default(uuid())
+  id                   String   @id @default(uuid())
   createdAt            DateTime @default(now())
   updatedAt            DateTime @updatedAt
   stripeCustomerId     String @db.Text
@@ -28583,7 +28583,7 @@ model Account {
 }
 
 model Invite {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   dateSent  DateTime @default(now())
   email     String @db.Text
   accountId String? @db.Text
@@ -28610,7 +28610,7 @@ provider = \\"mysql\\"
 }
 
 model Link {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   url       String @db.Text
@@ -28620,7 +28620,7 @@ model Link {
 }
 
 model User {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   name      String? @db.Text
@@ -28791,7 +28791,7 @@ model Profile {
 }
 
 model User {
-  email    String @db.Text    @unique
+  email    String    @unique
   name     String? @db.Text
   user_id  Int       @id @default(autoincrement())
   posts    Post[]
@@ -28832,17 +28832,17 @@ provider = \\"mysql\\"
 }
 
 model User {
-  id           String @db.Text        @id @default(uuid())
+  id           String        @id @default(uuid())
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
   name         String @db.Text
-  email        String @db.Text        @unique
+  email        String        @unique
   interactions Interaction[]
   playlists    Playlist[]
 }
 
 model Interaction {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   songId    String? @db.Text
@@ -28854,7 +28854,7 @@ model Interaction {
 }
 
 model Song {
-  id           String @db.Text        @id @default(uuid())
+  id           String        @id @default(uuid())
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
   name         String @db.Text
@@ -28871,7 +28871,7 @@ model Song {
 }
 
 model Artist {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   name      String @db.Text
@@ -28880,7 +28880,7 @@ model Artist {
 }
 
 model Album {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   name      String @db.Text
@@ -28890,7 +28890,7 @@ model Album {
 }
 
 model Playlist {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   userId    String? @db.Text
@@ -28917,17 +28917,17 @@ provider = \\"mysql\\"
 }
 
 model User {
-  id           String @db.Text        @id @default(uuid())
+  id           String        @id @default(uuid())
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
-  email        String @db.Text        @unique
+  email        String        @unique
   name         String @db.Text
   reservations Reservation[]
   reviews      Review[]
 }
 
 model Reservation {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   userId    String? @db.Text
@@ -28941,7 +28941,7 @@ model Reservation {
 }
 
 model Room {
-  id                 String @db.Text        @id @default(uuid())
+  id                 String        @id @default(uuid())
   createdAt          DateTime      @default(now())
   updatedAt          DateTime      @updatedAt
   totalOccupancy     Int           @default(5)
@@ -28960,7 +28960,7 @@ model Room {
 }
 
 model Review {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   rating    Int
@@ -28970,7 +28970,7 @@ model Review {
 }
 
 model Media {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   roomId    String? @db.Text
@@ -28996,7 +28996,7 @@ provider = \\"mysql\\"
 }
 
 model User {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   name      String? @db.Text
@@ -29006,7 +29006,7 @@ model User {
 }
 
 model Account {
-  id                   String @db.Text   @id @default(uuid())
+  id                   String   @id @default(uuid())
   createdAt            DateTime @default(now())
   updatedAt            DateTime @updatedAt
   stripeCustomerId     String @db.Text
@@ -29018,7 +29018,7 @@ model Account {
 }
 
 model Invite {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   dateSent  DateTime @default(now())
   email     String @db.Text
   accountId String? @db.Text
@@ -29044,7 +29044,7 @@ provider = \\"mysql\\"
 }
 
 model Link {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   url       String @db.Text
@@ -29054,7 +29054,7 @@ model Link {
 }
 
 model User {
-  id        String @db.Text   @id @default(uuid())
+  id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   name      String? @db.Text


### PR DESCRIPTION
Updates the MySQL file transformer to exclude the @id and @unique when converting String types to @db.Text.

#### TODO

- [ ] docs
- [ ] tests
