### PR TITLE
fix: rebuild when templates-raw changes

### DIFF
--- a/scripts/getReflectTemplatesCacheKey.sh
+++ b/scripts/getReflectTemplatesCacheKey.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
+
+templatesHash=$(find ./templates-raw -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum)
 generatorHash=$(find ./generator -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum)
 
 # Base64 encode because GH cache action does not support at least commas.
-cacheKey=$(echo "{ \"generator\":\"$generatorHash\" }" | base64)
+cacheKey=$(echo "{ \"templates\":\"$templatesHash\", \"generator\":\"$generatorHash\" }" | base64)
 
 echo $cacheKey
 


### PR DESCRIPTION
This PR triggers a `build:gen` instead of using the gh actions cache whenever `generator/` OR `templates-raw/` changes.